### PR TITLE
add scope_name in instance_norm_layer

### DIFF
--- a/module.py
+++ b/module.py
@@ -15,7 +15,7 @@ def instance_norm_layer(
     instance_norm_layer = tf.contrib.layers.instance_norm(
         inputs = inputs,
         epsilon = epsilon,
-        activation_fn = activation_fn)
+        activation_fn = activation_fn, name=name)
 
     return instance_norm_layer
 


### PR DESCRIPTION
The `name` variable in the function
```
def instance_norm_layer(
    inputs, 
    epsilon = 1e-06, 
    activation_fn = None, 
    name = None):

    instance_norm_layer = tf.contrib.layers.instance_norm(
        inputs = inputs,
        epsilon = epsilon,
        activation_fn = activation_fn)

    return instance_norm_layer
```
has no use.