### PR TITLE
Fix: You must call "start" before calling "update"

### DIFF
--- a/download.py
+++ b/download.py
@@ -17,6 +17,8 @@ def progress_bar(block_num, block_size, total_size):
         widgets = [progressbar.Percentage(), ' ', progressbar.Bar(marker = '>', left = '[', right = ']'), ' ', progressbar.ETA(), ' ', progressbar.FileTransferSpeed()] 
         pbar = progressbar.ProgressBar(widgets = widgets, maxval = total_size)
 
+    pbar.start()
+
     downloaded = block_num * block_size
     if downloaded < total_size:
         pbar.update(downloaded)


### PR DESCRIPTION
```
✗ python3 download.py --download_dir ./download2 --data_dir ./download_data2 --datasets vcc2016
Attempting to download: vcc2016_training.zip
Traceback (most recent call last):
  File "/Users/iomcr/code/gan/download.py", line 93, in <module>
    download_vcc2016(download_dir = download_dir, data_dir = data_dir)
  File "/Users/iomcr/code/gan/download.py", line 68, in download_vcc2016
    dataset_filepath = maybe_download(filename = data_file, url = url, destination_dir = download_dir, force = False)
  File "/Users/iomcr/code/gan/download.py", line 36, in maybe_download
    filepath, _ = urlretrieve(url, filepath, reporthook = progress_bar)
  File "/usr/local/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/urllib/request.py", line 265, in urlretrieve
    reporthook(blocknum, bs, size)
  File "/Users/iomcr/code/gan/download.py", line 22, in progress_bar
    pbar.update(downloaded)
  File "/usr/local/lib/python3.9/site-packages/progressbar/progressbar.py", line 257, in update
    raise RuntimeError('You must call "start" before calling "update"')
RuntimeError: You must call "start" before calling "update"
```